### PR TITLE
128-bit block and 128-bit key should use 10 rounds instead of 12 rounds

### DIFF
--- a/src/rijndael.rs
+++ b/src/rijndael.rs
@@ -19,19 +19,13 @@ impl Rijndael {
         if !VALID.contains(&key.len()) {
             return Err("Invalid key size");
         }
-        let rounds = if block_size == 32 {
+        let rounds = if block_size == 32 || key.len() == 32 {
             14
         } else {
-            let base = match key.len() {
-                16 => 10,
-                24 => 12,
-                32 => 14,
-                _ => return Err("Invalid key size2"),
-            };
-            if key.len() > 16 {
-                base
+            if block_size == 16 && key.len() == 16 {
+                10
             } else {
-                base + 2
+                12
             }
         };
         let b_c = block_size / 4;


### PR DESCRIPTION
From here https://www.eng.tau.ac.il/~yash/crypto-netsec/rijndael.htm

> Rijndael has a variable number of rounds. Not counting an extra round performed at the end of encipherment with one step omitted, the number of rounds in Rijndael is:
> - 9 if both the block and the key are 128 bits long.
> - 11 if either the block or the key is 192 bits long, and neither of them is longer than that.
> - 13 if either the block or the key is 256 bits long.